### PR TITLE
Fix Vercel 404 routing to use custom React 404 page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,10 +8,24 @@
       }
     }
   ],
+  "rewrites": [
+    {
+      "source": "/((?!api).*)",
+      "destination": "/index.html"
+    }
+  ],
   "routes": [
     {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "src": "/static/(.*)",
+      "headers": {
+        "cache-control": "s-maxage=31536000"
+      }
+    },
+    {
+      "src": "/assets/(.*)",
+      "headers": {
+        "cache-control": "s-maxage=31536000"
+      }
     }
   ]
 }


### PR DESCRIPTION
- Updated vercel.json to use rewrites instead of routes for SPA handling
- Added proper rewrites configuration to send all non-API routes to index.html
- Ensured React Router can handle 404s instead of Vercel's default page
- Added cache headers for static assets optimization
- Fixed client-side routing to work properly on Vercel deployment